### PR TITLE
Add qwertz german keyboard optimized for tablets

### DIFF
--- a/qwertz/latn_qwertz_de_tablet.xml
+++ b/qwertz/latn_qwertz_de_tablet.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file defines the QWERTY layout.
+
+A layout is made of keys arranged into rows. Keys can be made bigger with the
+'width' attribute and blank space can be added on the left of a key with the
+'shift' attribute.
+
+'key0' assigns the symbol on the middle of the key. 'key1', 'key2', etc..
+assign symbols to the corners of a key, they are arranged like this:
+
+1 7 2
+5 0 6
+3 8 4
+
+Keys prefixed with 'loc ' are not visible on the keyboard. They are used to
+specify a place for a key, if it needed to be added to the layout later.
+(for example, by the "Add keys to keyboard" option)
+
+See bottom_row.xml for the definition of the bottom row and neo2.xml for a
+layout that re-defines it.
+See srcs/juloo.keyboard2/KeyValue.java for the keys that have a special meaning.
+-->
+<keyboard bottom_row="false" name="QWERTZ DE Tablet" script="latin">
+    <row>
+        <key key0="esc" key4="loc esc"/>
+        <key key0="q" key1="!" key2="1"/>
+        <key key0="w" key3="^" key2="2" key1="&quot;" key4="\@"/>
+        <key key0="e" key1="§" key2="3" key4="€"/>
+        <key key0="r" key2="4" key1="$"/>
+        <key key0="t" key2="5" key1="%"/>
+        <key key0="z" key2="6" key1="&amp;"/>
+        <key key0="u" key1="/" key2="7" key3="ü" key4="{"/>
+        <key key0="i" key1="(" key2="8" key4="["/>
+        <key key0="o" key1=")" key2="9" key3="ö" key4="]"/>
+        <key key0="p" key2="0" key1="=" key4="}"/>
+        <key key0="ü" key1="+" key2="*" key3="~" key4="\?"/>
+        <key width="1.7" key0="backspace" key2="delete"/>
+    </row>
+    <row>
+        <key width="1.2" key0="tab"/>
+        <key key0="a" key2="`" key3="ä"/>
+        <key key0="s" key3="ß"/>
+        <key key0="d"/>
+        <key key0="f"/>
+        <key key0="g" key3="-"/>
+        <key key0="h"/>
+        <key key0="j"/>
+        <key key0="k"/>
+        <key key0="l"/>
+        <key key0="ö"/>
+        <key key0="ä" key1="#" key2="'" key3="/" key4="\\"/>
+        <key width="1.5" key0="enter"/>
+    </row>
+    <row>
+        <key width="1.5" key0="shift" key2="loc capslock"/>
+        <key key0="y" key1=">" key2="|" key3="&lt;"/>
+        <key key0="x" key1="loc †"/>
+        <key key0="c"/>
+        <key key0="v"/>
+        <key key0="b"/>
+        <key key0="n"/>
+        <key key0="m"/>
+        <key key0="," key1=";"/>
+        <key key0="." key1=":"/>
+        <key key0="-" key1="_"/>
+        <key width="2.2" key0="shift"/>
+    </row>
+    <row height="0.95">
+        <key width="2" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key4="switch_numeric"/>
+        <key width="1.5" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
+        <key width="8" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right" slider="true"/>
+        <key key0="loc compose" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down" key5="left" key6="right" key7="up" key8="down"/>
+        <key width="1.2" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key4="switch_numeric"/>
+    </row>
+</keyboard>


### PR DESCRIPTION
A german keyboard designed especially for tablets. Hint: Add numpad when in landscape mode.
The keyboard is designed such that each symbol is on the right place.