### PR TITLE
Add programmer_english qwerty layout

### DIFF
--- a/qwerty/programmer_english.xml
+++ b/qwerty/programmer_english.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<keyboard name="Programmer english" script="latin">
+<keyboard name="Programmer (English)" script="latin">
   <row>
-    <key c="q" nw="loc esc" se="("/>
-    <key c="w" se="{"/>
-    <key c="e" se="!"/>
-    <key c="r" sw="$"/>
-    <key c="t" sw="%"/>
-    <key c="y" sw="^" ne="loc redo"/>
-    <key c="u" sw="&amp;"/>
-    <key c="i" sw="*"/>
-    <key c="o" sw="}"/>
-    <key c="p" sw=")" ne="loc page_up"/>
+    <key c="q" nw="loc esc" se="(" ne="1"/>
+    <key c="w" se="{" ne="2"/>
+    <key c="e" se="!" ne="3"/>
+    <key c="r" sw="$" ne="4"/>
+    <key c="t" sw="%" ne="5"/>
+    <key c="y" sw="^" ne="loc redo" nw="6"/>
+    <key c="u" sw="&amp;" ne="7"/>
+    <key c="i" sw="*" ne="8"/>
+    <key c="o" sw="}" ne="9"/>
+    <key c="p" sw=")" ne="loc page_up" nw="0"/>
   </row>
   <row>
     <key shift="0.5" se="[" c="a" sw="loc selectAll" nw="loc tab"/>

--- a/qwerty/programmer_english.xml
+++ b/qwerty/programmer_english.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<keyboard name="Programmer english" script="latin">
+  <row>
+    <key c="q" nw="loc esc" se="("/>
+    <key c="w" se="{"/>
+    <key c="e" se="!"/>
+    <key c="r" sw="$"/>
+    <key c="t" sw="%"/>
+    <key c="y" sw="^" ne="loc redo"/>
+    <key c="u" sw="&amp;"/>
+    <key c="i" sw="*"/>
+    <key c="o" sw="}"/>
+    <key c="p" sw=")" ne="loc page_up"/>
+  </row>
+  <row>
+    <key shift="0.5" se="[" c="a" sw="loc selectAll" nw="loc tab"/>
+    <key c="s" ne="_" se="-"/>
+    <key c="d" nw="\\"/>
+    <key c="f" nw="+"/>
+    <key c="g" nw="/"/>
+    <key c="h" ne="="/>
+    <key c="j" ne=";"/>
+    <key c="k" sw="&quot;" nw="'"/>
+    <key c="l" ne="|" sw="]" se="loc page_down"/>
+  </row>
+  <row>
+    <key width="1.5" c="shift" ne="loc capslock"/>
+    <key c="z" ne="&lt;" sw="loc undo"/>
+    <key c="x" ne="," sw="loc cut"/>
+    <key c="c" nw=":" sw="loc copy"/>
+    <key c="v" ne="\#" sw="loc paste" se="loc pasteAsPlainText"/>
+    <key c="b" ne="\?"/>
+    <key c="n" nw="." se="`"/>
+    <key c="m" nw="&gt;" se="~"/>
+    <key width="1.5" c="backspace" ne="delete"/>
+  </row>
+</keyboard>


### PR DESCRIPTION
This layout is QWERTY-based, has all special characters that a programmer might need afaik. Also i mapped some special actions as copy, paste, undo, etc. I wanted to make at most 1 special character per key to make it easier to swipe-type, but there are too many symbols so i had to somehow put the remaining in the already mapped keys. This layout is targeted at landscape orientation and typing with thumbs, i tried to make the typing as intuitive as possible, if anyone have any suggestions - feel free to comment on this PR.