### PR TITLE
Add QWERTY Vi Touch layouts

### DIFF
--- a/qwerty/latn_qwerty_vi_touch.xml
+++ b/qwerty/latn_qwerty_vi_touch.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Staggered QWERTY Vi-centered keyboard layout centered around holding modifiers,
+ideal for touch typing on tablets or thumb typing on phones in landscape
+
+Licensed under Creative Commons CC0 1.0 Universal.
+See <https://creativecommons.org/publicdomain/zero/1.0/> for details.
+-->
+<keyboard
+  name="QWERTY (Vi Touch)"
+  bottom_row="false"
+  embedded_number_row="true"
+  locale_extra_keys="false"
+  script="latin">
+  <row>
+    <key c="`" indication="~" width="0.5"/>
+    <key c="1" indication="!・F1"/>
+    <key c="2" indication="@・F2"/>
+    <key c="3" indication="#・F3"/>
+    <key c="4" indication="$・F4"/>
+    <key c="5" indication="%・F5"/>
+    <key c="6" indication="^・F6"/>
+    <key c="7" indication="&amp;・F7"/>
+    <key c="8" indication="*・F8"/>
+    <key c="9" indication="(・F9"/>
+    <key c="0" indication=")・F10"/>
+    <key c="-" indication="_・F11"/>
+    <key c="=" indication="+・F12"/>
+    <key c="backspace" indication="⌦"/>
+  </row>
+  <row>
+    <key c="tab"/>
+    <key c="q"/>
+    <key c="w"/>
+    <key c="e"/>
+    <key c="r"/>
+    <key c="t"/>
+    <key c="y"/>
+    <key c="u"/>
+    <key c="i"/>
+    <key c="o"/>
+    <key c="p"/>
+    <key c="[" indication="{"/>
+    <key c="]" indication="}"/>
+    <key c="\\" indication="|・Ins" width="0.5"/>
+  </row>
+  <row>
+    <key c="esc" width="1.25"/>
+    <key c="a"/>
+    <key c="s"/>
+    <key c="d"/>
+    <key c="f"/>
+    <key c="g"/>
+    <key c="h"/>
+    <key c="j"/>
+    <key c="k"/>
+    <key c="l"/>
+    <key c=";" indication=":"/>
+    <key c="'" indication="&quot;"/>
+    <key c="enter" width="1.25"/>
+  </row>
+  <row>
+    <key c="shift" width="1.75"/>
+    <key c="z"/>
+    <key c="x"/>
+    <key c="c"/>
+    <key c="v"/>
+    <key c="b"/>
+    <key c="n"/>
+    <key c="m"/>
+    <key c="," indication="&lt;"/>
+    <key c="." indication="&gt;"/>
+    <key c="/" indication="?"/>
+    <key c="shift" width="1.75"/>
+  </row>
+  <row>
+    <key c="ctrl" width="0.75"/>
+    <key c="fn" key3="switch_numeric"/>
+    <key c="meta"/>
+    <key c="alt"/>
+    <key c="space"
+      key5="cursor_left"
+      key6="cursor_right"
+      indication="IM・Layout"
+      width="5"/>
+    <key c="alt"/>
+    <key c="meta"/>
+    <key c="ctrl"/>
+    <key c="left" width="0.43"/>
+    <key c="down" width="0.44"/>
+    <key c="up" width="0.44"/>
+    <key c="right" width="0.44"/>
+  </row>
+  <modmap>
+    <!-- Extra: Vi Touch -->
+    <fn a="backspace" b="delete"/>
+    <fn a="space" b="change_method_prev"/>
+
+    <!-- Extra -->
+    <fn a="-" b="f11"/>
+    <fn a="=" b="f12"/>
+    <fn a="\\" b="insert"/>
+    <shift a="change_method_prev" b="switch_forward"/>
+
+    <!-- Row: 1234 -->
+    <shift a="`" b="~"/>
+    <shift a="1" b="!"/>
+    <shift a="2" b="@"/>
+    <shift a="3" b="#"/>
+    <shift a="4" b="$"/>
+    <shift a="5" b="%"/>
+    <shift a="6" b="^"/>
+    <shift a="7" b="&amp;"/>
+    <shift a="8" b="*"/>
+    <shift a="9" b="("/>
+    <shift a="0" b=")"/>
+    <shift a="-" b="_"/>
+    <shift a="=" b="+"/>
+
+    <!-- Row: QWERTY -->
+    <shift a="[" b="{"/>
+    <shift a="]" b="}"/>
+    <shift a="\\" b="|"/>
+
+    <!-- Row: ASDF -->
+    <shift a=";" b=":"/>
+    <shift a="'" b="&quot;"/>
+
+    <!-- Row: ZXCV -->
+    <shift a="," b="&lt;"/>
+    <shift a="." b="&gt;"/>
+    <shift a="/" b="?"/>
+  </modmap>
+</keyboard>

--- a/qwerty/latn_qwerty_vi_touch_portrait.xml
+++ b/qwerty/latn_qwerty_vi_touch_portrait.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Staggered QWERTY Vi-centered keyboard layout centered around holding modifiers,
+ideal for typing on phones in portrait
+
+Licensed under Creative Commons CC0 1.0 Universal.
+See <https://creativecommons.org/publicdomain/zero/1.0/> for details.
+-->
+<keyboard
+  name="QWERTY (Vi Touch Portrait)"
+  bottom_row="false"
+  embedded_number_row="true"
+  locale_extra_keys="false"
+  script="latin">
+  <row>
+    <key c="`" indication="~"/>
+    <key c="tab"/>
+    <key c="change_method_prev" indication="Layout"/>
+    <key c="-" indication="_・F11"/>
+    <key c="=" indication="+・F12"/>
+    <key c=";" indication=":"/>
+    <key c="'" indication="&quot;"/>
+    <key c="[" indication="{"/>
+    <key c="]" indication="}"/>
+    <key c="\\" indication="|・Ins"/>
+    <key c="delete"/>
+  </row>
+  <row>
+    <key c="1" indication="!・F1"/>
+    <key c="2" indication="@・F2"/>
+    <key c="3" indication="#・F3"/>
+    <key c="4" indication="$・F4"/>
+    <key c="5" indication="%・F5"/>
+    <key c="6" indication="^・F6"/>
+    <key c="7" indication="&amp;・F7"/>
+    <key c="8" indication="*・F8"/>
+    <key c="9" indication="(・F9"/>
+    <key c="0" indication=")・F10"/>
+    <key c="backspace"/>
+  </row>
+  <row>
+    <key c="q" shift="0.5"/>
+    <key c="w"/>
+    <key c="e"/>
+    <key c="r"/>
+    <key c="t"/>
+    <key c="y"/>
+    <key c="u"/>
+    <key c="i"/>
+    <key c="o"/>
+    <key c="p"/>
+  </row>
+  <row>
+    <key c="esc" width="0.75"/>
+    <key c="a"/>
+    <key c="s"/>
+    <key c="d"/>
+    <key c="f"/>
+    <key c="g"/>
+    <key c="h" indication="←"/>
+    <key c="j" indication="↓"/>
+    <key c="k" indication="↑"/>
+    <key c="l" indication="→"/>
+    <key c="enter" width="1.25"/>
+  </row>
+  <row>
+    <key c="shift" width="1.25"/>
+    <key c="z"/>
+    <key c="x"/>
+    <key c="c"/>
+    <key c="v"/>
+    <key c="b"/>
+    <key c="n"/>
+    <key c="m"/>
+    <key c="," indication="&lt;" width="0.87"/>
+    <key c="." indication="&gt;" width="0.88"/>
+    <key c="shift"/>
+  </row>
+  <row>
+    <key c="ctrl"/>
+    <key c="fn" key3="switch_numeric"/>
+    <key c="meta"/>
+    <key c="alt"/>
+    <key c="space"
+      key5="cursor_left"
+      key6="cursor_right"
+      width="3"/>
+    <key c="/" indication="?"/>
+    <key c="alt"/>
+    <key c="meta"/>
+    <key c="ctrl"/>
+  </row>
+  <modmap>
+    <!-- Extra: Vi Touch Portrait -->
+    <fn a="h" b="left"/>
+    <fn a="j" b="down"/>
+    <fn a="k" b="up"/>
+    <fn a="l" b="right"/>
+
+    <!-- Extra -->
+    <fn a="-" b="f11"/>
+    <fn a="=" b="f12"/>
+    <fn a="\\" b="insert"/>
+    <shift a="change_method_prev" b="switch_forward"/>
+
+    <!-- Row: 1234 -->
+    <shift a="`" b="~"/>
+    <shift a="1" b="!"/>
+    <shift a="2" b="@"/>
+    <shift a="3" b="#"/>
+    <shift a="4" b="$"/>
+    <shift a="5" b="%"/>
+    <shift a="6" b="^"/>
+    <shift a="7" b="&amp;"/>
+    <shift a="8" b="*"/>
+    <shift a="9" b="("/>
+    <shift a="0" b=")"/>
+    <shift a="-" b="_"/>
+    <shift a="=" b="+"/>
+
+    <!-- Row: QWERTY -->
+    <shift a="[" b="{"/>
+    <shift a="]" b="}"/>
+    <shift a="\\" b="|"/>
+
+    <!-- Row: ASDF -->
+    <shift a=";" b=":"/>
+    <shift a="'" b="&quot;"/>
+
+    <!-- Row: ZXCV -->
+    <shift a="," b="&lt;"/>
+    <shift a="." b="&gt;"/>
+    <shift a="/" b="?"/>
+  </modmap>
+</keyboard>


### PR DESCRIPTION
I found the built-in QWERTY layout awkward to use on a tablet, so I made this Vi Touch layout that is similar to the classic ANSI layout, except for a few minor changes.

Instead of swiping, you hold down the modifier keys, like on a physical keyboard.

The `Caps Lock` key is replaced with `Esc`, hence the `Vi` in the name.

The indication format is `Shift` or `Shift・Fn`. For example, the indication for `1` is `!・F1`, meaning it will become `!` when `Shift` is active or `F1` when `Fn` is active.

Explicitly licensed under CC0 for eventual inclusion in the app.

Vi Touch
---

Ideal for touch typing on tablets or thumb typing on phones in landscape.

<details>
    <summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/fcfaea03-9ba8-400a-84db-7810d57ffe80)
</details>

Vi Touch Portrait
---

Ideal for typing on phones in portrait. Uses more screen space than the Vi Touch layout, but the keys are easier to tap.

<details>
    <summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/c1a167f6-8fd3-4983-8ee6-28c8306abc5d)
</details>