### PR TITLE
Add Esperanto keyboard layouts

### DIFF
--- a/qwerty/eo-qwerty.xml
+++ b/qwerty/eo-qwerty.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This keyboard adds the Esperanto-specific diacritic letters: ĉ ĝ ĥ ĵ ŝ ŭ as northwest swipes.
+It also adds the (obsolete) Spesmilo currency sign and the culturally significant star symbol.
+Contributed by Haley Halcyon
+-->
+<keyboard name="QWERTY (Esperanto)" script="latin">
+  <row>
+    <key c="q" ne="1" se="loc esc"/>
+    <key c="w" nw="~" ne="2" sw="\@"/>
+    <key c="e" nw="!" ne="3" sw="\#" se="loc €"/>
+    <key c="r" ne="4" sw="$"/>
+    <key c="t" ne="5" sw="%"/>
+    <key c="y" ne="6" sw="^"/>
+    <key c="u" nw="ŭ" ne="7" sw="&amp;"/>
+    <key c="i" ne="8" sw="*"/>
+    <key c="o" ne="9" sw="(" se=")"/>
+    <key c="p" ne="0"/>
+  </row>
+  <row>
+    <key shift="0.5" c="a" nw="loc tab" ne="`"/>
+    <key c="s" ne="loc §" nw="ŝ" se="₷" sw="loc ß"/>
+    <key c="d" ne="★" nw="☆" />
+    <key c="f"/>
+    <key c="g" ne="-" nw="ĝ" sw="_"/>
+    <key c="h" ne="=" nw="ĥ" sw="+"/>
+    <key c="j" nw="ĵ" se="}" sw="{"/>
+    <key c="k" sw="[" se="]"/>
+    <key c="l" ne="|" sw="\\"/>
+  </row>
+  <row>
+    <key width="1.5" c="shift" ne="loc capslock"/>
+    <key c="z"/>
+    <key c="x" ne="loc †"/>
+    <key c="c" ne="&lt;" nw="ĉ" sw="."/>
+    <key c="v" ne="&gt;" sw=","/>
+    <key c="b" ne="\?" sw="/"/>
+    <key c="n" ne=":" sw=";"/>
+    <key c="m" ne="&quot;" sw="'"/>
+    <key width="1.5" c="backspace" ne="delete"/>
+  </row>
+</keyboard>

--- a/qwerty/eo-sxgxertux.xml
+++ b/qwerty/eo-sxgxertux.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This keyboard adds the Esperanto-specific diacritic letters: ĉ ĝ ĥ ĵ ŝ ŭ by implementing the de-facto standard ŜĜERTŬ layout
+which replaces the letters Q, W, X, and Y (not used in Esperanto) with four of the six letters, and adds the 2 remaining letters as keys on the right.
+It also adds the (obsolete) Spesmilo currency sign and the culturally significant star symbol.
+Contributed by Haley Halcyon
+-->
+<keyboard name="ŜĜERTŬ (Esperanto)" script="latin">
+  <modmap>
+    <fn a="ŝ" b="₷" />
+  </modmap>
+  <row>
+    <key c="ŝ" ne="1" se="q" sw="loc esc"/>
+    <key c="ĝ" nw="~" ne="2" sw="\@" se="w"/>
+    <key c="e" nw="!" ne="3" sw="\#" se="loc €"/>
+    <key c="r" ne="4" sw="$"/>
+    <key c="t" ne="5" nw="tre " se="tro " sw="&percnt;" />
+    <key c="ŭ" ne="6" nw="aŭ" sw="^" se="y"/>
+    <key c="u" ne="7" sw="&amp;"/>
+    <key c="i" ne="8" nw="ist" sw="*"/>
+    <key c="o" ne="9" nw="ojn " sw="(" se=")"/>
+    <key width="1.2" c="p" ne="0" nw="por " sw="pri " se="per " />
+  </row>
+  <row>
+    <key width="1.2" c="a" nw="ajn" se="ant" sw="loc tab" ne="`"/>
+    <key c="s" ne="loc §" sw="loc ß" />
+    <key c="d" ne="de " nw="dis" />
+    <key c="f" ne="★" nw="☆" />
+    <key c="g" ne="-" sw="_"/>
+    <key c="h" ne="=" sw="+"/>
+    <key c="j" nw="jes" se="}" sw="{"/>
+    <key c="k" nw="kaj " sw="kun " />
+    <key c="l" nw="la " sw="[" se="]" />
+    <key c="ĵ" ne="|" sw="\\" />
+  </row>
+  <row>
+    <key c="shift" ne="loc capslock"/>
+    <key c="z" ne="loc †" nw="Zamenhof" />
+    <key c="ĉ" ne="ĉar " sw="ĉu " se="x" />
+    <key c="c" ne="&lt;" sw="."/>
+    <key c="v" ne="&gt;" sw=","/>
+    <key c="b" ne="\?" sw="/"/>
+    <key c="n" ne=":" sw=";"/>
+    <key c="m" ne="&quot;" sw="'"/>
+    <key c="ĥ" nw="Esperant" />
+    <key width="1.2" c="backspace" ne="delete"/>
+  </row>
+</keyboard>


### PR DESCRIPTION
This pull request adds two layouts for the language Esperanto.

ŜĜERTŬ: 
![Screenshot_20250703-160210 Discord](https://github.com/user-attachments/assets/d98fccc2-1ec5-4270-bfe2-4c8502b2830f)


QWERTY with swipe targets: 
![Screenshot_20250703-160214 Discord](https://github.com/user-attachments/assets/abe3ad6f-6e6c-485a-b3a8-9a7f3b04e7e6)
